### PR TITLE
#34 전반적인 레이아웃 수정

### DIFF
--- a/src/pages/FeedPage/index.tsx
+++ b/src/pages/FeedPage/index.tsx
@@ -37,12 +37,11 @@ const FeedPage = () => {
 
 const FeedPageWrapper = styled.section`
   overflow: scroll;
-  width: 100vw;
-  height: calc(100vh - 190px);
+  overflow-x: hidden;
+  width: 100%;
+  height: calc(100vh - 160px);
 `;
-const FeedItem = styled.div`
-  margin-bottom: 40px;
-`;
+const FeedItem = styled.div``;
 const FeedTopWrapper = styled.div`
   display: flex;
   justify-content: space-between;
@@ -71,12 +70,12 @@ const FeedAvatarName = styled.div`
 `;
 const FeedContentWrapper = styled.div``;
 const FeedContentImg = styled.div`
-  width: 100vw;
+  width: 100%;
   height: 100vw;
   background-color: grey;
 `;
 const FeedContentClassWrapper = styled.div`
-  width: 100vw;
+  width: 100%;
   height: 60px;
   background: linear-gradient(135deg, #b88bd6 0%, #b88bd6 0.01%, #a8bac8 100%);
   display: flex;

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -123,8 +123,9 @@ const HomePage = () => {
 
 const MainPageWrapper = styled.div`
   overflow: scroll;
+  overflow-x: hidden;
   width: 100%;
-  height: calc(100vh - 190px);
+  height: calc(100vh - 160px);
 `;
 
 const Container = styled.div`
@@ -175,8 +176,9 @@ const Title = styled.div`
 `;
 const BestClassesWrapper = styled.section``;
 const BestClassItemWrapper = styled.div`
-  width: 100vw;
-  overflow: scroll;
+  width: 100%;
+  overflow-y: hidden;
+  overflow-x: auto;
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -203,8 +205,8 @@ const BestClassesTitle = styled.div`
 const NewClassesWrapper = styled.section`
   margin-top: 40px;
   padding-bottom: 40px;
-  width: calc(100vw - 40px);
-  overflow: none;
+  width: 100%;
+  overflow-x: auto;
 `;
 const NewClassesItemWrapper = styled.div`
   display: grid;

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -41,7 +41,9 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   max-width: 640px;
-  width: 100%;
+  height: 100vh;
+  position: relative;
+  margin: auto;
 `;
 const StyledMain = styled.main`
   flex: 1;

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled';
 import React from 'react';
+import styled from '@emotion/styled';
 import { Header } from './Header';
 import { Navigator } from './Navigator';
 
@@ -43,6 +43,7 @@ const Container = styled.div`
   max-width: 640px;
   height: 100vh;
   position: relative;
+  overflow-x: hidden;
   margin: auto;
 `;
 const StyledMain = styled.main`

--- a/src/template/Header/Header.tsx
+++ b/src/template/Header/Header.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable react/react-in-jsx-scope */
+import React from 'react';
 import styled from '@emotion/styled';
 import { Bell, ChevronDown } from 'react-feather';
 import { Link } from 'react-router-dom';
@@ -32,6 +32,7 @@ const HeaderWrapper = styled.header`
   width: 100%;
   height: 95px;
   background: linear-gradient(135deg, #b88bd6 0%, #b88bd6 0.01%, #a8bac8 100%);
+  z-index: 1000;
 `;
 
 const Title = styled.h1`

--- a/src/template/Header/Header.tsx
+++ b/src/template/Header/Header.tsx
@@ -23,7 +23,7 @@ const Header = () => {
 };
 
 const HeaderWrapper = styled.header`
-  position: fix;
+  position: sticky;
   top: 0px;
   left: 0px;
   display: flex;
@@ -32,7 +32,6 @@ const HeaderWrapper = styled.header`
   width: 100%;
   height: 95px;
   background: linear-gradient(135deg, #b88bd6 0%, #b88bd6 0.01%, #a8bac8 100%);
-  position: relative;
 `;
 
 const Title = styled.h1`

--- a/src/template/Navigator/Navigator.tsx
+++ b/src/template/Navigator/Navigator.tsx
@@ -1,38 +1,41 @@
+import React from 'react';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { Home, Grid, Search, Circle } from 'react-feather';
 
-/* eslint-disable react/react-in-jsx-scope */
 const Navigator = () => {
+  const navIcons = [
+    {
+      to: '/',
+      Icon: Home,
+      contents: '메인화면',
+    },
+    {
+      to: '/feed',
+      Icon: Grid,
+      contents: '피드',
+    },
+    {
+      to: '/search',
+      Icon: Search,
+      contents: '검색하기',
+    },
+    {
+      to: '/user',
+      Icon: Circle,
+      contents: '내정보',
+    },
+  ];
   return (
     <NavWrapper>
-      <Link to="/" style={{ textDecoration: 'none', marginLeft: '20px' }}>
-        <IconWrapper>
-          <Home size={30} />
-          <IconDescription>메인화면</IconDescription>
-        </IconWrapper>
-      </Link>
-
-      <Link to="/feed" style={{ textDecoration: 'none' }}>
-        <IconWrapper>
-          <Grid size={30} />
-          <IconDescription>피드</IconDescription>
-        </IconWrapper>
-      </Link>
-
-      <Link to="/search" style={{ textDecoration: 'none' }}>
-        <IconWrapper>
-          <Search size={30} />
-          <IconDescription>검색하기</IconDescription>
-        </IconWrapper>
-      </Link>
-
-      <Link to="/" style={{ textDecoration: 'none', marginRight: '20px' }}>
-        <IconWrapper>
-          <Circle size={30} />
-          <IconDescription>내정보</IconDescription>
-        </IconWrapper>
-      </Link>
+      {navIcons.map(({ to, Icon, contents }) => (
+        <Link to={to} key={to} style={{ textDecoration: 'none' }}>
+          <IconWrapper>
+            <Icon size={30} />
+            <IconDescription>{contents}</IconDescription>
+          </IconWrapper>
+        </Link>
+      ))}
     </NavWrapper>
   );
 };

--- a/src/template/Navigator/Navigator.tsx
+++ b/src/template/Navigator/Navigator.tsx
@@ -38,11 +38,12 @@ const Navigator = () => {
 };
 
 const NavWrapper = styled.nav`
-  position: fix;
+  position: sticky;
   bottom: 0;
   left: 0;
+  right: 0;
+  height: 65px;
   width: 100%;
-  height: 95px;
   border-top: solid 1px #c4c4c4;
   display: flex;
   justify-content: space-between;
@@ -50,7 +51,6 @@ const NavWrapper = styled.nav`
 `;
 
 const IconWrapper = styled.div`
-  align-items: center;
   text-align: center;
   width: 100%;
   color: black;

--- a/src/template/Navigator/Navigator.tsx
+++ b/src/template/Navigator/Navigator.tsx
@@ -51,6 +51,8 @@ const NavWrapper = styled.nav`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  background-color: white;
+  box-sizing: border-box;
 `;
 
 const IconWrapper = styled.div`


### PR DESCRIPTION
|![image](https://user-images.githubusercontent.com/61727311/144436810-16bbacb2-a34f-4d68-8fd0-70b314730159.png)|![image](https://user-images.githubusercontent.com/61727311/144436910-74dc2233-fcde-4e42-9b6b-753b1e3a86ba.png)| 
|--|--|

## 구현 설명 
- 전체 페이지 중앙으로 정렬 (margin : auto를 설정하여 중앙정렬)
- 바텀네비게이션 고정될수 있도록 수정 (우선 sticky를 이용하여 고정을 하였습니다.)
- 바텀네비게이션 리팩토링 (좀더 편한 사용성을 위해 리팩토링)
- 홈페이지, 피드페이지 레이아웃 변경 (vw -> %로 변경, overflow-x : hidden 설정, height 값 변경 등)
- fix 오타 수정 (헤더와 네비게이션 부분 position: fix; 이렇게 되어있었습니다 ㅠㅜ @chloe41297 )


## PR 포인트 
- 이제부터 저도 PR올리시는 부분들 꼼꼼하게 확인하도록 하겠습니다 😀🤣

## Todo
- 추후 상태관리를 통해 현재페이지가 어디인지 확인하면 각 케이스에 맞는 조건을 정해 헤더나 바텀을 보여줄수 있도록 처리할 수 있을 것 같습니다.
