### PR TITLE
#70 productsDetail 도메인 구현, 디자인 변경

### DIFF
--- a/src/components/base/Avatar/index.tsx
+++ b/src/components/base/Avatar/index.tsx
@@ -73,7 +73,7 @@ const AvatarWrapper = styled.div<{ shape: Props['shape'] }>`
   border-radius: ${({ shape }) => ShapeToCssValue[shape]};
   background-color: #eee;
   overflow: hidden;
-
+  height: 100%;
   > img {
     transition: opacity 0.2s ease-out;
   }

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -11,8 +11,8 @@ interface Props {
   placeholder?: string;
   src: string;
   block?: boolean;
-  width: number;
-  height: number;
+  width: number | string;
+  height: number | string;
   alt: string;
   mode: Mode;
   style?: CSSProperties;

--- a/src/components/base/Modal/index.tsx
+++ b/src/components/base/Modal/index.tsx
@@ -59,12 +59,20 @@ const ModalContainer = styled.div`
   position: fixed;
   bottom: 0;
   left: 0;
+  right: 0;
+  margin: auto;
   max-width: 640px;
-  padding: 8px;
   background-color: white;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
   box-sizing: border-box;
   overflow-y: auto;
+  & {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export default Modal;

--- a/src/components/base/index.tsx
+++ b/src/components/base/index.tsx
@@ -1,3 +1,4 @@
+export { default as Avatar } from './Avatar';
 export { default as Modal } from './Modal';
 export { default as Upload } from './Upload';
 export { default as Image } from './Image';

--- a/src/components/domain/AteliarInformation/index.tsx
+++ b/src/components/domain/AteliarInformation/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Avatar, Text } from '../../base';
+
+interface Props {
+  profileImg: string;
+  name: string;
+  location: string;
+  phoneNumber: string;
+  openTime: string;
+}
+
+const AteliarInformation = ({ profileImg, name, location, phoneNumber, openTime }: Props) => {
+  return (
+    <AteliarContainer>
+      <Avatar size={80} src={profileImg} shape={'circle'} placeholder={''} alt={'profile'} />
+      <ContentWrapper>
+        <StyledText strong>{name}</StyledText>
+        <StyledText>{location}</StyledText>
+        <StyledText>{phoneNumber}</StyledText>
+        <StyledText>{openTime}</StyledText>
+      </ContentWrapper>
+    </AteliarContainer>
+  );
+};
+
+const AteliarContainer = styled.div`
+  display: flex;
+  margin: 20px 40px;
+`;
+const ContentWrapper = styled.div`
+  margin-left: 30px;
+  display: flex;
+  flex-direction: column;
+`;
+const StyledText = styled(Text)`
+  font-size: 18px;
+  margin: 5px 0;
+`;
+export default AteliarInformation;

--- a/src/components/domain/SimpleReview/index.tsx
+++ b/src/components/domain/SimpleReview/index.tsx
@@ -18,7 +18,7 @@ const SimpleReview = ({ children, date }: Props) => {
 const ReveiwWrapper = styled.div`
   background-color: #ddd;
   width: 90%;
-  margin: 15px 0;
+  margin-top: 20px;
   padding: 0 15px;
   box-sizing: border-box;
   border-radius: 15px;

--- a/src/components/domain/SimpleReview/index.tsx
+++ b/src/components/domain/SimpleReview/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+interface Props {
+  children: React.ReactChild;
+  date: string;
+}
+
+const SimpleReview = ({ children, date }: Props) => {
+  return (
+    <ReveiwWrapper>
+      <ContentWrapper>{children}</ContentWrapper>
+      <DateWrapper>{date}</DateWrapper>
+    </ReveiwWrapper>
+  );
+};
+
+const ReveiwWrapper = styled.div`
+  background-color: #ddd;
+  width: 90%;
+  margin: 15px 0;
+  padding: 0 15px;
+  box-sizing: border-box;
+  border-radius: 15px;
+`;
+const ContentWrapper = styled.div`
+  margin: 10px 0;
+`;
+const DateWrapper = styled(ContentWrapper)`
+  display: flex;
+  justify-content: flex-end;
+`;
+export default SimpleReview;

--- a/src/components/domain/index.tsx
+++ b/src/components/domain/index.tsx
@@ -1,2 +1,3 @@
 export { default as GoBack } from './Goback';
 export { default as SimpleReview } from './SimpleReview';
+export { default as AteliarInformation } from './AteliarInformation';

--- a/src/components/domain/index.tsx
+++ b/src/components/domain/index.tsx
@@ -1,1 +1,2 @@
 export { default as GoBack } from './Goback';
+export { default as SimpleReview } from './SimpleReview';

--- a/src/pages/ProductsDetailPage/index.tsx
+++ b/src/pages/ProductsDetailPage/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
 import { Image, Modal, Text } from '../../components/base';
 import { X } from 'react-feather';
-import { SimpleReview } from '../../components/domain';
+import { AteliarInformation, SimpleReview } from '../../components/domain';
 
 const ProductsDetailPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -58,13 +58,21 @@ const ProductsDetailPage = () => {
 
       <AuthorDetailContainer>
         <HeaderText>작가 정보</HeaderText>
-        <div>위치 보기</div>
-        {/* 스크롤 되었을 때, 확인을 위해 임시로 넣어둠*/}
-        <input style={{ width: 200, height: 2000 }} />
+        <AteliarInformation
+          profileImg={
+            'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png'
+          }
+          name={'희진 공방'}
+          location={'서울시 송파구 100번지'}
+          phoneNumber={'010-5555-3333'}
+          openTime={'9 : 00 ~ 18 : 00'}
+        />
+
+        <HeaderText>위치 보기</HeaderText>
       </AuthorDetailContainer>
 
       <ReservationContainer>
-        <div>가격 45,000</div>
+        <HeaderText>45,000</HeaderText>
         <ReservationButton>예약하기</ReservationButton>
       </ReservationContainer>
 
@@ -74,6 +82,7 @@ const ProductsDetailPage = () => {
         width={'100%'}
         height={'80%'}
       >
+        {/* 바깥 스크롤 막기 추가 */}
         <ModalHeader>
           <StyledButton onClick={() => setVisible(false)}>
             <X size={40} />
@@ -99,9 +108,7 @@ const ProductsDetailPage = () => {
   );
 };
 
-// min-height는 우선 어떠한 모양으로 나올지 보는 것이기 때문에 나중에 삭제
 const ProductsDetailContainer = styled.div`
-  min-height: 100px;
   margin: 20px 0;
   border-bottom: 2px solid black;
 `;
@@ -118,7 +125,6 @@ const HeaderText = styled(Text)`
   font-weight: 700;
 `;
 const ProductReviewContainer = styled.div`
-  min-height: 100px;
   margin: 20px 0;
   border-bottom: 2px solid black;
 `;
@@ -133,7 +139,7 @@ const MoreReviewWrapper = styled.div`
   margin: 20px 0;
 `;
 const AuthorDetailContainer = styled.div`
-  min-height: 100px;
+  padding-bottom: 60px;
 `;
 const ReservationContainer = styled.div`
   position: fixed;
@@ -164,12 +170,12 @@ const StyledModal = styled(Modal)`
 const ModalHeader = styled.div`
   background: linear-gradient(135deg, #b88bd6 0%, #b88bd6 0.01%, #a8bac8 100%);
   height: 56px;
+  display: flex;
+  justify-content: flex-end;
 `;
 const StyledButton = styled.button`
   background: none;
   border: none;
-  right: 0;
-  position: relative;
 `;
 const ReviewContainer = styled.div`
   display: flex;
@@ -177,7 +183,6 @@ const ReviewContainer = styled.div`
   align-items: center;
 `;
 const ReviewWrapper = styled.div`
-  min-height: 100px;
   width: 90%;
   background-color: lightcyan;
   margin: 20px 0;

--- a/src/pages/ProductsDetailPage/index.tsx
+++ b/src/pages/ProductsDetailPage/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
 import { Image, Modal, Text } from '../../components/base';
 import { X } from 'react-feather';
+import { SimpleReview } from '../../components/domain';
 
 const ProductsDetailPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -46,8 +47,13 @@ const ProductsDetailPage = () => {
         <HeaderText>
           후기<span>(999+)</span>
         </HeaderText>
-        <div> 우선 그냥 후기(내용, 날짜?)</div>
-        <div onClick={() => setVisible(true)}>+ 후기 더보기</div>
+        <SimpleReviewContainer>
+          <SimpleReview date={'2010-05-17'}>좋아요좋아요~</SimpleReview>
+          <SimpleReview date={'2010-03-08'}>좋아요좋아요~</SimpleReview>
+        </SimpleReviewContainer>
+        <MoreReviewWrapper>
+          <span onClick={() => setVisible(true)}>+ 후기 더보기</span>
+        </MoreReviewWrapper>
       </ProductReviewContainer>
 
       <AuthorDetailContainer>
@@ -115,6 +121,16 @@ const ProductReviewContainer = styled.div`
   min-height: 100px;
   margin: 20px 0;
   border-bottom: 2px solid black;
+`;
+const SimpleReviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const MoreReviewWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin: 20px 0;
 `;
 const AuthorDetailContainer = styled.div`
   min-height: 100px;

--- a/src/pages/ProductsDetailPage/index.tsx
+++ b/src/pages/ProductsDetailPage/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
-import { Modal } from '../../components/base';
+import { Image, Modal, Text } from '../../components/base';
+import { X } from 'react-feather';
 
 const ProductsDetailPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -13,59 +14,107 @@ const ProductsDetailPage = () => {
 
   return (
     <>
-      <div>ProductsDetailPage {id} 입니다.</div>
-      <img src="https://via.placeholder.com/150" />
+      <Image
+        height={'210px'}
+        width={'100%'}
+        src={'https://i.pinimg.com/564x/eb/02/19/eb021934d0750d0b91ad6d6ff3e4ed84.jpg'}
+        alt={'class'}
+        mode={'cover'}
+        placeholder={'https://via.placeholder.com/150'}
+      />
 
       <ProductsDetailContainer>
-        <ProductsNameWrapper>
-          <div>클래스 이름</div>
+        <ProductNameWrapper>
+          <HeaderText>클래스 이름</HeaderText>
           <div>별점 4.0</div>
-        </ProductsNameWrapper>
-        <div>클래스 소개</div>
-        <div>커리큘럼</div>
+        </ProductNameWrapper>
+        <ProductContentWrapper>
+          <HeaderText>클래스 소개</HeaderText>
+          <div> 랩몬스터와 슈가의 음악감상하기 클래스입니다.</div>
+          <div> 랩몬스터와 슈가의 음악감상하기 클래스입니다.</div>
+          <div> 랩몬스터와 슈가의 음악감상하기 클래스입니다.</div>
+        </ProductContentWrapper>
+        <ProductContentWrapper>
+          <HeaderText>커리큘럼</HeaderText>
+          <div> 우선 춤을 배웁니다.</div>
+          <div> 우선 춤을 배웁니다.</div>
+          <div> 우선 춤을 배웁니다.</div>
+        </ProductContentWrapper>
       </ProductsDetailContainer>
 
-      <ProductsReviewContainer>
-        <div>
-          후기<span>999+</span>
-        </div>
+      <ProductReviewContainer>
+        <HeaderText>
+          후기<span>(999+)</span>
+        </HeaderText>
         <div> 우선 그냥 후기(내용, 날짜?)</div>
         <div onClick={() => setVisible(true)}>+ 후기 더보기</div>
-      </ProductsReviewContainer>
+      </ProductReviewContainer>
 
       <AuthorDetailContainer>
-        <div>작가 정보들들...</div>
+        <HeaderText>작가 정보</HeaderText>
         <div>위치 보기</div>
+        {/* 스크롤 되었을 때, 확인을 위해 임시로 넣어둠*/}
+        <input style={{ width: 200, height: 2000 }} />
       </AuthorDetailContainer>
 
       <ReservationContainer>
         <div>가격 45,000</div>
         <ReservationButton>예약하기</ReservationButton>
       </ReservationContainer>
-      <ModalWrapper>
-        <Modal visible={visible} onClose={() => setVisible(false)} width={'100%'} height={'70%'}>
-          <button onClick={() => setVisible(false)}>Close</button>
-          <div>별점</div>
-          <ReviewWrapper>후기1</ReviewWrapper>
+
+      <StyledModal
+        visible={visible}
+        onClose={() => setVisible(false)}
+        width={'100%'}
+        height={'80%'}
+      >
+        <ModalHeader>
+          <StyledButton onClick={() => setVisible(false)}>
+            <X size={40} />
+          </StyledButton>
+        </ModalHeader>
+        <div>별점</div>
+        <ReviewContainer>
+          {/* 리뷰 보여주는 칸은 컴포넌트화 */}
+          <ReviewWrapper>
+            후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가
+            길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가
+            길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가 길면후기1가
+            길면후기1가 길면후기1가 길면후기1가 길면
+          </ReviewWrapper>
           <ReviewWrapper>후기2</ReviewWrapper>
           <ReviewWrapper>후기2</ReviewWrapper>
           <ReviewWrapper>후기2</ReviewWrapper>
           <ReviewWrapper>후기2</ReviewWrapper>
           <ReviewWrapper>후기2</ReviewWrapper>
-        </Modal>
-      </ModalWrapper>
+        </ReviewContainer>
+      </StyledModal>
     </>
   );
 };
+
+// min-height는 우선 어떠한 모양으로 나올지 보는 것이기 때문에 나중에 삭제
 const ProductsDetailContainer = styled.div`
   min-height: 100px;
+  margin: 20px 0;
+  border-bottom: 2px solid black;
 `;
-const ProductsNameWrapper = styled.div`
+const ProductNameWrapper = styled.div`
   display: flex;
   justify-content: space-between;
+  margin: 20px 0;
 `;
-const ProductsReviewContainer = styled.div`
+const ProductContentWrapper = styled.div`
+  margin: 20px 0;
+`;
+const HeaderText = styled(Text)`
+  font-size: 25px;
+  font-weight: 700;
+`;
+const ProductReviewContainer = styled.div`
   min-height: 100px;
+  margin: 20px 0;
+  border-bottom: 2px solid black;
 `;
 const AuthorDetailContainer = styled.div`
   min-height: 100px;
@@ -73,9 +122,14 @@ const AuthorDetailContainer = styled.div`
 const ReservationContainer = styled.div`
   position: fixed;
   width: 100%;
+  max-width: 640px;
   display: flex;
-  bottom: 10px;
+  bottom: 65px;
+  background-color: #aaa;
+  z-index: 100;
+  display: flex;
   justify-content: space-around;
+  align-items: center;
 `;
 const ReservationButton = styled.button`
   height: 56px;
@@ -86,13 +140,30 @@ const ReservationButton = styled.button`
   font-size: 25px;
   line-height: 29px;
 `;
-const ModalWrapper = styled.div`
-  width: 100%;
+const StyledModal = styled(Modal)`
+  border-top-right-radius: 20px;
+  border-top-left-radius: 20px;
+`;
+
+const ModalHeader = styled.div`
+  background: linear-gradient(135deg, #b88bd6 0%, #b88bd6 0.01%, #a8bac8 100%);
+  height: 56px;
+`;
+const StyledButton = styled.button`
+  background: none;
+  border: none;
+  right: 0;
+  position: relative;
+`;
+const ReviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 const ReviewWrapper = styled.div`
-  height: 100px;
-  width: 100%;
-  background-color: blue;
+  min-height: 100px;
+  width: 90%;
+  background-color: lightcyan;
   margin: 20px 0;
 `;
 export default ProductsDetailPage;


### PR DESCRIPTION
|![image](https://user-images.githubusercontent.com/61727311/144974301-10917d89-e649-4607-9ef5-8a6adf80c37b.png)|![image](https://user-images.githubusercontent.com/61727311/144974329-35edeca9-3b86-4135-95f7-cdfff743cf00.png)| 
|--|--|

|![image](https://user-images.githubusercontent.com/61727311/144974440-02306a1b-415f-434d-8ccf-67ad655b99aa.png)|![image](https://user-images.githubusercontent.com/61727311/144974329-35edeca9-3b86-4135-95f7-cdfff743cf00.png)| 
|--|--|

## 구현 설명 

- SimpleReview 도메인을 만들어 적용할 수 있도록 구현했습니다.
- AteliarInformation 도메인을 만들어 작가정보를 쉽게 입력할 수 있도록 하였습니다.
- 모달 중앙으로 오도록 정렬, 모달 스크롤 안보이도록 만듬


## Todo :
- 첫 이미지들이 여러장일때 처리?
- 모달의 리뷰 정보들 도메인 만들기
- 페이지 전체적인 마진(여백) 정리

