### PR TITLE
#154 유효한 사용자인지 check, privateRoute 재설정

### DIFF
--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,3 +1,3 @@
-export { userState } from './user';
+export { userState, authUserState } from './user';
 export { navigationState } from './navigation';
 export { modalState, locationState } from './modal';

--- a/src/atoms/user.ts
+++ b/src/atoms/user.ts
@@ -17,3 +17,8 @@ export const userState = atom<IUser>({
     atelierId: 1,
   },
 });
+
+export const authUserState = atom<boolean | null>({
+  key: 'authUserState',
+  default: null,
+});

--- a/src/constants/sessionStorage.ts
+++ b/src/constants/sessionStorage.ts
@@ -1,0 +1,3 @@
+export const sessionStorageToken = {
+  token: 'dayz-token',
+};

--- a/src/routes/CustomRoutes/PrivateRoute.tsx
+++ b/src/routes/CustomRoutes/PrivateRoute.tsx
@@ -4,6 +4,8 @@ import { useRecoilValue } from 'recoil';
 import { authUserState } from '../../atoms';
 
 interface IProps {
+  path: string;
+  exact: boolean;
   component: any;
 }
 

--- a/src/routes/CustomRoutes/index.tsx
+++ b/src/routes/CustomRoutes/index.tsx
@@ -1,0 +1,1 @@
+export { default as PrivateRoute } from './PrivateRoute';

--- a/src/routes/PrivateRoute/index.tsx
+++ b/src/routes/PrivateRoute/index.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
-import { getSessionStorageItem } from '../../utils/functions';
+import { useRecoilValue } from 'recoil';
+import { authUserState } from '../../atoms';
 
 interface IProps {
   component: any;
 }
 
 const PrivateRoute = ({ component: Component, ...rest }: IProps) => {
-  // 토큰이 있다면 접근 가능 토근이 없다면 접근 불가.
-  // 이름 바꿔야함
-  const isLogin = getSessionStorageItem('somethingToken', '');
+  const authUser = useRecoilValue(authUserState);
 
   return (
     <Route
       {...rest}
-      render={(props) => (isLogin ? <Component {...props} /> : <Redirect to="/" />)}
+      render={(props) => (authUser ? <Component {...props} /> : <Redirect to="/" />)}
     />
   );
 };

--- a/src/routes/PrivateRoute/index.tsx
+++ b/src/routes/PrivateRoute/index.tsx
@@ -13,7 +13,7 @@ const PrivateRoute = ({ component: Component, ...rest }: IProps) => {
   return (
     <Route
       {...rest}
-      render={(props) => (authUser ? <Component {...props} /> : <Redirect to="/" />)}
+      render={(props) => (authUser ? <Component {...props} /> : <Redirect to="/login" />)}
     />
   );
 };

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -16,22 +16,23 @@ interface Props {
 
 const DefaultTemplate = ({ children }: Props): JSX.Element => {
   const { topNavigation, bottomNavigation } = useRecoilValue(navigationState);
-  const token = getSessionStorageItem(sessionStorageToken.token, '');
-  const setUserData = useSetRecoilState(userState);
-  const setAuthUser = useSetRecoilState(authUserState);
 
-  const AuthUser = useCallback(async () => {
-    const response = await checkAuthorizationUser({ token });
-    if (response.status === 200) {
-      setUserData({ ...response.data.data });
-      setAuthUser(true);
-    } else {
-      setAuthUser(false);
-    }
-  }, [token]);
-  useEffect(() => {
-    AuthUser();
-  }, [AuthUser]);
+  // 로그인 기능 + storage에 token을 넣는 기능이 추가되면 주석을 풀어주세요.
+  // const token = getSessionStorageItem(sessionStorageToken.token, '');
+  // const setUserData = useSetRecoilState(userState);
+  // const setAuthUser = useSetRecoilState(authUserState);
+
+  // const AuthUser = useCallback(async () => {
+  //   const response = await checkAuthorizationUser({ token });
+  //   if (response.status === 200) {
+  //     setUserData({ ...response.data.data });
+  //     setAuthUser(true);
+  //   }
+  // }, [token]);
+  //
+  // useEffect(() => {
+  //   AuthUser();
+  // }, [AuthUser]);
 
   return (
     <Container>

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -1,16 +1,37 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import styled from '@emotion/styled';
 import Header from './Header';
 import Navigator from './Navigator';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { navigationState } from '../atoms/navigation';
+import { authUserState, userState } from '../atoms';
+import { getSessionStorageItem } from '../utils/functions';
+import { checkAuthorizationUser } from '../utils/api/dayzApi';
+import { sessionStorageToken } from '../constants/sessionStorage';
 
 interface Props {
   children: React.ReactNode;
 }
+// eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJwcm92aWRlcklkIjoiMjAxOTk0ODQ5MSIsInJvbGVzIjpbIlJPTEVfVVNFUiJdLCJpc3MiOiJkYXl6IiwiaWQiOjEsImV4cCI6MTYzOTc4MTc1MSwiaWF0IjoxNjM5NzIxNzUxLCJ1c2VybmFtZSI6Iuq5gOyngO2biCJ9.Up9c43nhy6fNvkufA81obPflC-kPMrWVkOo2nplLwOqEKuvehpy3z3am180UTERJYsPsLpqvVxVtixRGSCTw3A
 
 const DefaultTemplate = ({ children }: Props): JSX.Element => {
   const { topNavigation, bottomNavigation } = useRecoilValue(navigationState);
+  const token = getSessionStorageItem(sessionStorageToken.token, '');
+  const setUserData = useSetRecoilState(userState);
+  const setAuthUser = useSetRecoilState(authUserState);
+
+  const AuthUser = useCallback(async () => {
+    const response = await checkAuthorizationUser({ token });
+    if (response.status === 200) {
+      setUserData({ ...response.data.data });
+      setAuthUser(true);
+    } else {
+      setAuthUser(false);
+    }
+  }, [token]);
+  useEffect(() => {
+    AuthUser();
+  }, [AuthUser]);
 
   return (
     <Container>

--- a/src/utils/api/dayzApi.ts
+++ b/src/utils/api/dayzApi.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { API_METHOD } from '../../constants/apiConstant';
-import { AtelierClass, Email, Location, searhClassTypes } from './types';
+import { AtelierClass, Email, Location, Token, searhClassTypes } from './types';
 
 const axiosInstance = axios.create();
 
@@ -22,11 +22,10 @@ export const something = ({ email, password }: Email) => {
   });
 };
 
-// 예시2. token을 사용해야 할 경우
-export const requiredtoken = (token: string) => {
+export const checkAuthorizationUser = ({ token }: Token) => {
   return request({
     method: API_METHOD.GET,
-    url: `/main`,
+    url: '/api/v1/members/info',
     headers: {
       Authorization: token,
     },

--- a/src/utils/functions/sessionStorage.ts
+++ b/src/utils/functions/sessionStorage.ts
@@ -1,15 +1,15 @@
-export const getSessionStorageItem = (key: string, initialState: unknown) => {
+export const getSessionStorageItem = (key: string | undefined, initialState: unknown) => {
   try {
-    const item = sessionStorage.getItem(key);
+    const item = sessionStorage.getItem(key as string);
     return item ? JSON.parse(item) : initialState;
   } catch (error) {
     return initialState;
   }
 };
 
-export const setSessionStorageItem = (key: string, value: unknown) => {
+export const setSessionStorageItem = (key: string | undefined, value: unknown) => {
   try {
-    sessionStorage.setItem(key, JSON.stringify(value));
+    sessionStorage.setItem(key as string, JSON.stringify(value));
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
|![image](https://user-images.githubusercontent.com/61727311/146559641-33615884-8716-4234-b6d4-e771da1939eb.png)|![image](https://user-images.githubusercontent.com/61727311/146559713-8ff3fa8f-3695-443b-868c-451206f9ab35.png)| 
|--|--|

## 구현 설명 

- defaultTemplate에서 유효한 사용자인지 판단하는 로직 구현 
  - sessionStorage에 토큰이 있는지 확인한다 -> checkAuthorizationUser api호출을 하여 data를 받고 유효한 사용자이면setUserData({ ...response.data.data }) - 유저 상태에 data 넣는 작업,     setAuthUser(true) - 유효한 사용자인지 확인하는 작업 을 실행한다.

- privateRoute 바로 사용할 수 있도록 구현(사진 2) 저렇게 사용하시면 됩니다.
## PR 포인트 (필수 아님)

