### PR TITLE
#161 결제 성공 페이지 추가, state 넘겨주기 

### DIFF
--- a/src/atoms/modal.ts
+++ b/src/atoms/modal.ts
@@ -7,7 +7,7 @@ import { IModalState } from './types';
 export const modalState = atom<IModalState>({
   key: 'modalState',
   default: {
-    modalView: true,
+    modalView: false,
   },
 });
 

--- a/src/components/base/Button/index.tsx
+++ b/src/components/base/Button/index.tsx
@@ -4,11 +4,12 @@ import React from 'react';
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   type: 'button' | 'submit' | 'reset';
+  onclick?: any;
 }
 
-const Button = ({ children, type, ...props }: Props) => {
+const Button = ({ children, type, onClick, ...props }: Props) => {
   return (
-    <StyledButton type={type} style={{ ...props.style }} {...props}>
+    <StyledButton type={type} style={{ ...props.style }} onClick={onClick} {...props}>
       {children}
     </StyledButton>
   );

--- a/src/components/domain/LocationSetting/index.tsx
+++ b/src/components/domain/LocationSetting/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import React, { useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useRecoilState, useRecoilValueLoadable } from 'recoil';
 import { ErrorMessage } from '..';
 import { locationState, userState } from '../../../atoms';
@@ -26,10 +27,10 @@ interface Props {
 }
 
 const LocationSetting = ({ setVisible }: Props) => {
+  const history = useHistory();
   const [pickState, setPickState] = useState<string | ''>('');
   const [userInfo, setUserInfo] = useRecoilState(userState);
   const [errorMessage, setErrorMessage] = useState('');
-
   const { state, contents } = useRecoilValueLoadable(locationState);
   const locationList: LocationType[] = useMemo(() => {
     if (state === 'hasValue') {
@@ -62,6 +63,7 @@ const LocationSetting = ({ setVisible }: Props) => {
         regionName,
       }));
       setVisible(false);
+      history.push('/');
       Toast.show('성공적으로 변경되었습니다.', 2000);
     } catch (e: any) {
       Toast.show(e.message);

--- a/src/pages/booking/DUMMY_DATA.ts
+++ b/src/pages/booking/DUMMY_DATA.ts
@@ -1,0 +1,33 @@
+type Data = { time: string; available: number };
+
+export const Dummy_TIME_Data: Data[] = [
+  {
+    time: '09:00 - 10:00',
+    available: 3,
+  },
+  {
+    time: '11:00 - 12:00',
+    available: 2,
+  },
+  {
+    time: '14:00 - 16:00',
+    available: 0,
+  },
+
+  {
+    time: '13:00 - 14:00',
+    available: 1,
+  },
+  {
+    time: '16:00 - 17:00',
+    available: 5,
+  },
+];
+
+export const DUMMY_PRICE_DATA = {
+  price: 12000,
+};
+
+export const DUMMY_TOTAL_PEOPLE = {
+  maxPeople: 5,
+};

--- a/src/pages/booking/SuccessBookPage.tsx
+++ b/src/pages/booking/SuccessBookPage.tsx
@@ -46,9 +46,15 @@ const SuccessBookPage = () => {
   }, []);
 
   const handleClick = (linkto: string) => {
-    history.push(linkto); // replace로 바꾸기
+    history.replace(linkto);
   };
-  if (loading) return <div>결제중입니다.</div>;
+  if (loading)
+    return (
+      <LoadingWrapper>
+        <LoadingText>결제중입니다.</LoadingText>
+      </LoadingWrapper>
+    );
+
   return (
     <StyledSection>
       <CheckedWrapper>
@@ -73,6 +79,17 @@ const SuccessBookPage = () => {
     </StyledSection>
   );
 };
+const LoadingWrapper = styled.div`
+  display: flex;
+  height: 70vh;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+`;
+
+const LoadingText = styled.div`
+  font-size: 30px;
+`;
 
 const StyledSection = styled.section`
   margin: 0 20px;

--- a/src/pages/booking/SuccessBookPage.tsx
+++ b/src/pages/booking/SuccessBookPage.tsx
@@ -1,7 +1,102 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import { Button } from '../../components/base';
+import { AiOutlineCheckCircle } from 'react-icons/ai';
+import { useEffect } from 'react';
+import styled from '@emotion/styled';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import { navigationState } from '../../atoms';
 
 const SuccessBookPage = () => {
-  return <div>123</div>;
+  const location = useLocation();
+  const history = useHistory();
+  const [loading, setLoading] = useState(true);
+  const date = new Date();
+
+  const setNavState = useSetRecoilState(navigationState);
+  const resetNavState = useResetRecoilState(navigationState);
+  useEffect(() => {
+    setNavState((prev) => ({
+      ...prev,
+      bottomNavigation: false,
+    }));
+    return () => {
+      resetNavState();
+    };
+  }, []);
+
+  console.log(location.state);
+
+  // useEffect(() => {
+  //   if (!location.state) {
+  //     history.replace('/');
+  //   }
+
+  // }, []);
+
+  const handleClick = (linkto: string) => {
+    history.push(linkto); // replace로 바꾸기
+  };
+
+  return (
+    <StyledSection>
+      <CheckedWrapper>
+        <AiOutlineCheckCircle size={100} color="purple" />
+        <SuccessText>성공적으로 예약되었습니다!</SuccessText>
+      </CheckedWrapper>
+      <ContentsWrapper>
+        <StyledText>결제 상품 : ㄴㄴㄴ클래스</StyledText>
+        <StyledText>예약 번호 : 123123123</StyledText>
+        <StyledText>예약 날짜 : 2020.123.</StyledText>
+        <StyledText>결제 금액 : 12000원</StyledText>
+        <StyledText>결제 날짜 : {date.toLocaleString()}</StyledText>
+      </ContentsWrapper>
+      <ButtonWrapper>
+        <StyledButton type="button" onClick={() => handleClick('/feed')}>
+          <StyledText>피드 둘러보기</StyledText>
+        </StyledButton>
+        <StyledButton type="button" onClick={() => handleClick('/')}>
+          <StyledText>메인으로 돌아가기</StyledText>
+        </StyledButton>
+      </ButtonWrapper>
+    </StyledSection>
+  );
 };
 
+const StyledSection = styled.section`
+  margin: 0 20px;
+`;
+
+const CheckedWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 40px 0;
+`;
+const SuccessText = styled.div`
+  font-weight: bold;
+  font-size: 25px;
+  margin-top: 10px;
+`;
+const ContentsWrapper = styled.div`
+  margin: 20px 0;
+  margin-bottom: 30px;
+`;
+const StyledText = styled.div`
+  margin: 10px 0;
+  font-size: 20px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const StyledButton = styled(Button)`
+  display: block;
+  width: 80%;
+  height: 60px;
+  border-radius: 15px;
+  margin: 10px 0;
+`;
 export default SuccessBookPage;

--- a/src/pages/booking/SuccessBookPage.tsx
+++ b/src/pages/booking/SuccessBookPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SuccessBookPage = () => {
+  return <div>123</div>;
+};
+
+export default SuccessBookPage;

--- a/src/pages/booking/SuccessBookPage.tsx
+++ b/src/pages/booking/SuccessBookPage.tsx
@@ -7,11 +7,18 @@ import styled from '@emotion/styled';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
 import { navigationState } from '../../atoms';
 
+interface Data {
+  date: string;
+  name: string;
+  price: number;
+}
+
 const SuccessBookPage = () => {
   const location = useLocation();
   const history = useHistory();
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const date = new Date();
+  const [data, setDate] = useState<any>({});
 
   const setNavState = useSetRecoilState(navigationState);
   const resetNavState = useResetRecoilState(navigationState);
@@ -24,20 +31,24 @@ const SuccessBookPage = () => {
       resetNavState();
     };
   }, []);
+  useEffect(() => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+    }, 3000);
+  }, []);
 
-  console.log(location.state);
-
-  // useEffect(() => {
-  //   if (!location.state) {
-  //     history.replace('/');
-  //   }
-
-  // }, []);
+  useEffect(() => {
+    if (!location.state) {
+      history.replace('/');
+    }
+    setDate({ ...(location.state as any) });
+  }, []);
 
   const handleClick = (linkto: string) => {
     history.push(linkto); // replace로 바꾸기
   };
-
+  if (loading) return <div>결제중입니다.</div>;
   return (
     <StyledSection>
       <CheckedWrapper>
@@ -45,10 +56,10 @@ const SuccessBookPage = () => {
         <SuccessText>성공적으로 예약되었습니다!</SuccessText>
       </CheckedWrapper>
       <ContentsWrapper>
-        <StyledText>결제 상품 : ㄴㄴㄴ클래스</StyledText>
+        <StyledText>결제 상품 : {data.name}</StyledText>
         <StyledText>예약 번호 : 123123123</StyledText>
-        <StyledText>예약 날짜 : 2020.123.</StyledText>
-        <StyledText>결제 금액 : 12000원</StyledText>
+        <StyledText>예약 날짜 : {data.date}</StyledText>
+        <StyledText>결제 금액 : {data.price}원</StyledText>
         <StyledText>결제 날짜 : {date.toLocaleString()}</StyledText>
       </ContentsWrapper>
       <ButtonWrapper>

--- a/src/pages/booking/index.tsx
+++ b/src/pages/booking/index.tsx
@@ -1,1 +1,2 @@
 export { default as BookingPage } from './BookingPage';
+export { default as SuccessBookPage } from './SuccessBookPage';

--- a/src/pages/category/CategoryPage.tsx
+++ b/src/pages/category/CategoryPage.tsx
@@ -13,7 +13,7 @@ const CategoryPage = () => {
   const resetModalState = useResetRecoilState(modalState);
   useEffect(() => {
     setModalState(() => ({
-      modalView: false,
+      modalView: true,
     }));
     return () => {
       resetModalState();

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { Image } from '../../components/base';
 import { categoryIcons } from '../../constants/categoryItems';
 import { DUMMY_NEW_ATELIER_DATA, DUMMY_POPULAR_DATA } from './DUMMY_DATA';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import { modalState } from '../../atoms';
 
 // 1. 카테고리 목록 조회 https://backend-devcourse.notion.site/d1a5d88893d642a48e169f5ccc10cc7c
 // 2. 금주의 인기 클래스 조회 https://backend-devcourse.notion.site/66ebc05aa398421dbf463023b8a9224f
@@ -11,6 +13,17 @@ import { DUMMY_NEW_ATELIER_DATA, DUMMY_POPULAR_DATA } from './DUMMY_DATA';
 // 동기 처리하면 DUMMY_DATA는 삭제
 
 const HomePage = () => {
+  const setModalState = useSetRecoilState(modalState);
+  const resetModalState = useResetRecoilState(modalState);
+  useEffect(() => {
+    setModalState(() => ({
+      modalView: true,
+    }));
+    return () => {
+      resetModalState();
+    };
+  }, []);
+
   return (
     <MainPageWrapper>
       <Container>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ export { default as LoginPage } from './LoginPage';
 export { default as RedirectPageAfterKakao } from './LoginPage/RedirectPageAfterKakao';
 export { default as SignupCheckLocation } from './LoginPage/SignupCheckLocation';
 export { default as SignupAuthorInfo } from './LoginPage/SignupAuthorInfo';
-export { BookingPage } from './booking';
+export { BookingPage, SuccessBookPage } from './booking';
 
 export { SearchPage, SearchResultsPage } from './search';
 export {

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -1,12 +1,22 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
-import { userState } from '../../atoms';
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { modalState, userState } from '../../atoms';
 import { GoBack } from '../../components/domain';
 import { searchClasses } from '../../utils/api/dayzApi';
 
 const SearchPage = () => {
+  const setModalState = useSetRecoilState(modalState);
+  const resetModalState = useResetRecoilState(modalState);
+  useEffect(() => {
+    setModalState(() => ({
+      modalView: true,
+    }));
+    return () => {
+      resetModalState();
+    };
+  }, []);
   const history = useHistory();
   const [userInfo, setUserInfo] = useRecoilState(userState);
   const [searchList, setSearchList] = useState('');

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -8,6 +8,7 @@ import {
   HomePage,
   ProductsDetailPage,
   BookingPage,
+  SuccessBookPage,
   SearchPage,
   UserPage,
   NotFoundPage,
@@ -38,6 +39,7 @@ const Router = () => {
       <Route path="/search" exact component={SearchPage} />
       <Route path="/workshop/:id" component={WorkshopPage} />
       <Route path="/products/:id" exact component={ProductsDetailPage} />
+      <Route path="/booking/success" exact component={SuccessBookPage} />
       <Route path="/booking/:id" exact component={BookingPage} />
       <Route path="/user/book" exact component={UserBookedPage} />
       <Route path="/user/review" exact component={UserReviewPage} />


### PR DESCRIPTION
|![image](https://user-images.githubusercontent.com/61727311/146649060-6bd3ddf3-f4b6-4795-a569-72e834f49ba7.png)|![image](https://user-images.githubusercontent.com/61727311/146649267-6864350a-ea3c-4f17-935e-c4b2003f53f0.png)| 
|--|--|

## 구현 설명 

- 결제 성공했을때 나오는 페이지 추가
- state가 없을시 home으로 route 처리
- 결제 로딩 추가

## PR 포인트 (필수 아님)

